### PR TITLE
Make Escape key smarter based on docking or floating dialog

### DIFF
--- a/src/MultiReplace.cpp
+++ b/src/MultiReplace.cpp
@@ -881,6 +881,8 @@ INT_PTR CALLBACK MultiReplace::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 
             }
         }
+        else
+            DockingDlgInterface::run_dlgProc( message, wParam, lParam );
     }
     break;
 
@@ -928,8 +930,15 @@ INT_PTR CALLBACK MultiReplace::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 
         case IDCANCEL :
         {
-            EndDialog(_hSelf, 0);
-            _MultiReplace.display(false);
+            if (_MultiReplace.isFloating())
+            {
+                EndDialog(_hSelf, 0);
+                _MultiReplace.display(false);
+            }
+            else
+            {
+                ::SetFocus( getCurScintilla() );
+            }
         }
         break;
 

--- a/src/MultiReplace.h
+++ b/src/MultiReplace.h
@@ -108,6 +108,10 @@ public:
         _hParent = parent2set;
     };
 
+	bool isFloating() const {
+		return _isFloating;
+	};
+
 protected:
     virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -104,6 +104,12 @@ bool setCommand(size_t index, TCHAR* cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey*
 //-- STEP 4. DEFINE YOUR ASSOCIATED FUNCTIONS --//
 //----------------------------------------------//
 
+HWND getCurScintilla()
+{
+    int which = -1;
+    ::SendMessage(nppData._nppHandle, NPPM_GETCURRENTSCINTILLA, 0, ( LPARAM )&which);
+    return ( which == 0 ) ? nppData._scintillaMainHandle : nppData._scintillaSecondHandle;
+}
 
 void multiReplace()
 {

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -70,6 +70,7 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 //
 // Your plugin command functions
 //
+HWND getCurScintilla();
 void multiReplace();
 void about();
 


### PR DESCRIPTION
If the dialog is just opened as a floating window, Escape key should - and currently does - close the floating dialog window. If however the dialog is docked to the Notepad++ window in one of the four (top, bottom, left, or right) docking spots, Escape key should not close the dialog; rather, it should set focus to the current Scintilla editing component. The thought is if the dialog is docked, the user may want to use it multiple times while swapping back and forth to navigate through the document.

Need to add some simple subs to detect the current Scintilla and a method to retrieve the floating status in the DockingDlgInterface subclass.

Core Notepad++ plugin template files stay untouched.

Fix #19