### PR TITLE
Fix 32-bit warning as error for signed mismatch

### DIFF
--- a/src/MultiReplace.cpp
+++ b/src/MultiReplace.cpp
@@ -2140,7 +2140,7 @@ void MultiReplace::saveSettingsToIni(const std::wstring& iniFilePath) {
     // Store List
     WritePrivateProfileString(L"List", NULL, NULL, iniFilePathLpc);  // delete all entries first
     WritePrivateProfileString(L"List", L"Count", std::to_wstring(replaceListData.size()).c_str(), iniFilePathLpc);
-    for (int i = 0; i < replaceListData.size(); i++) {
+    for (size_t i = 0; i < replaceListData.size(); i++) {
         const ReplaceItemData& item = replaceListData[i];
         std::wstring listFindTextData = encodeLengthPrefixedString(item.findText);
         std::wstring listReplaceTextData = encodeLengthPrefixedString(item.replaceText);


### PR DESCRIPTION
Use `size_t` to define `for` iterator instead of `int` as per other fixes.

Fix #21